### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This Python build tool enables a given user to calculate a variety of different 
 
 # Methods
 
-#### Assesing Privacy risk: 
+#### Assessing Privacy risk:
 
 - K-anonymity [^1]
 - ℓ-diversity [^2]
@@ -31,14 +31,14 @@ This Python build tool enables a given user to calculate a variety of different 
 
 # Input data format
 
-Input can be in either CSV or TSV format. 
-For meta information an option of load of json file is possible. 
+Input can be in either CSV or TSV format.
+For meta information, an option to load a JSON file is available.
 
 # Software installation
 
 
 ### Option 1
-The metaprivBIDS software runs on multiple platforms (e.g. Linux, MacOS, Windows) that have a Python 3 installation.
+The metaprivBIDS software runs on multiple platforms (e.g. Linux, macOS, Windows) that have a Python 3 installation.
 It is recommended (but not required) to first create a virtual environment.
 
   
@@ -59,7 +59,7 @@ Activates the environment.
 conda activate venv 
 ```
 
-Graphviz requires system level dependencies as well as rpy2 and might need to be installed with 
+Graphviz requires system-level dependencies as well as rpy2 and might need to be installed with
 
 ```console
 conda create --name venv -c conda-forge "python>=3.7" graphviz pygraphviz r-base r-sdcMicro rpy2
@@ -102,7 +102,7 @@ git clone https://github.com/CPernet/metaprivBIDS.git
 
 # Dependencies
 
-To execute the program make sure all dependencies from pyproject.toml is available in a python 3.7 environment as stated in the software installation. 
+To execute the program, make sure all dependencies from pyproject.toml are available in a Python 3.7 environment as stated in the software installation.
 This can be done by first ```cd``` into the MetaprivBIDS directory and then running
 
 ```console

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -70,24 +70,24 @@ This is an interactive step-by-step guide:
             "<p style='margin-top: 16px;'>1) the smaller the size of the MSU within a record, the higher the risk associated with that record.<br>" + 
             "2) the greater the number of MSUs contained in the record, the higher its risk." +
 
-            "<p style='margin-top: 16px;'> The user will be asked to fill out both the specified max size of variables to consider. This can be a minimum of 1 field and max of total amount of fields available.<br>" +
-            " The Data Intrusion Simulation (DIS) metric has to be between 0 to 1, the default is set to: 0.2. The higher the DIS, the more background knowledge we assume an adversary has.",
+            "<p style='margin-top: 16px;'> The user will be asked to specify the maximum size of variables to consider. This can be a minimum of 1 field and a maximum of the total number of available fields.<br>" +
+            " The Data Intrusion Simulation (DIS) metric has to be between 0 and 1; the default is set to 0.2. The higher the DIS, the more background knowledge we assume an adversary has.",
 
             "Step 6: To see a preview of the data the user can push the Preview Data Button.",
 
             "Step 7: The Preview Data button takes the user to a new page with different options for data anonymization, e.g., round values, combine categorical values, etc.",
 
             "Step 8: The Combine Categorical button provides the user with an option to generalise categorical values.<br>" + 
-            "<p style='margin-top: 16px;'> We can for example see from out test data, that it would make sense to combine all educational steps below high school into one category called 'K-12 education'." ,
+            "<p style='margin-top: 16px;'> We can for example see from our test data that it would make sense to combine all educational steps below high school into one category called 'K-12 education'." ,
 
             "Step 9: To keep track of changed categorical values, the user has the option to push the Graph Categorical button, which keeps track of changes for categorical values.",
 
             "Step 10: Returning back to the Main Menu we can push the Privacy Information Factor button.",
 
             "Step 11: This takes the user to a new page where the Cell Information Gain (CIG) can be computed." +
-            " Importantly the user has the option to specify if there is any missing values in form of (NaN) values or other entries indicating missing values. In this case the computation of CIG will automatically set these to 0, ensuring that they do not count towards a privacy risk.",
+            " Importantly, the user has the option to specify if there are any missing values in the form of (NaN) values or other entries indicating missing values. In this case, the computation of CIG will automatically set these to 0, ensuring that they do not count toward a privacy risk.",
 
-            "Sep 12: This will then prompt the CIG value for all individual cell values. To get the privacy risk for the row, the RIG is computed and displayed in the outmost right field." +
+            "Step 12: This will then prompt the CIG value for all individual cell values. To get the privacy risk for the row, the RIG is computed and displayed in the outermost right field." +
             " For the dataset we see that rows with index 169, 167, 37, 52 & 159 are the top 5 rows with the highest risk." +
             " Additionally we see that PIF is 21.38, higher than the recommended guidelines seen below." +
 
@@ -101,16 +101,16 @@ This is an interactive step-by-step guide:
             " Safe Level 4: 0.04 ≤ PIF < 0.11 <br>" +
             " Safe Level 5: PIF < 0.04 <br>" +
             
-            "<p style='margin-top: 16px;'> The user can based on this information choose to anynomise the data further by use of the methods from the preview page or manually outside the program discard rows with a user-specficed threshold", 
+            "<p style='margin-top: 16px;'> The user can, based on this information, choose to anonymise the data further by using the methods from the preview page or, manually outside the program, discard rows with a user-specified threshold",
 
 
-            "Step 13: To access the data privacy risk on a field level we can use the Generate CIG Heatpmap button.<br>" +
-            " This gives the user the opportunity to directly view which quasi-identfiers contribute the most to the overall risk in the dataset." +
+            "Step 13: To access the data privacy risk on a field level we can use the Generate CIG Heatmap button.<br>" +
+            " This gives the user the opportunity to directly view which quasi-identifiers contribute the most to the overall risk in the dataset." +
             
             "<p style='margin-top: 16px;'> For example, here we see that Age has a very high contribution to the risk factor whereas Sex and Salary-class contribute less.",
 
-            "Step 14: After having performed some of the anonymising techniques from the preview page, we see a big improvement to our over Privacy information Factor." +
-            "<p style='margin-top: 16px;'> The user is advised to keep track of the trade-off between utility and privacy, hence there is not a one solution fits all in regards to which anonymisation techniques to use, but rather a suggestion to what could be done to improve the available risk privacy measures from the metaprivBIDS platform." ,
+            "Step 14: After having performed some of the anonymising techniques from the preview page, we see a big improvement to our overall Privacy Information Factor." +
+            "<p style='margin-top: 16px;'> The user is advised to keep track of the trade-off between utility and privacy; there is no one-size-fits-all solution regarding which anonymisation techniques to use, but rather suggestions for improving the available privacy risk measures from the metaprivBIDS platform." ,
             
 
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -4,10 +4,10 @@ Getting Started
 Welcome to the Getting Started guide for metaprivBIDS.
 This Python build tool enables a user to calculate a variety of different data privacy metrics on tabular data from a user interface.  
 
-installation
+Installation
 ------------
 
-The metaprivBIDS software runs on multiple platforms (e.g. Linux, MacOS, Windows) that have a Python 3.7 installation.
+The metaprivBIDS software runs on multiple platforms (e.g. Linux, macOS, Windows) that have a Python 3.7 installation.
 It is recommended (but not required) to first create a virtual environment. This can be done with ``venv`` or, if pygraphviz fails (as it happens), with ``conda``.
 
 .. code-block:: bash
@@ -30,7 +30,7 @@ You can then install metaprivBIDS by cloning the git repository.
     git clone https://github.com/CPernet/metaprivBIDS.git
 
 
-To execute the program make sure all dependencies from pyproject.toml is available in a python 3.7 environment. 
+To execute the program, make sure all dependencies from pyproject.toml are available in a Python 3.7 environment.
 This can be done by running
 
 .. code-block:: bash
@@ -100,5 +100,5 @@ Next Steps
 ----------
 
 
-- Explore the :ref:`Examples <examples_section>` to see Interactive Tutorial of how to navigate the graphical user interface for MetaprivBIDS.
+- Explore the :ref:`Examples <examples_section>` to see an interactive tutorial on how to navigate the graphical user interface for MetaprivBIDS.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,15 +6,15 @@
 Welcome to metaprivBIDS documentation!
 ======================================================
 
-This documentation provides an overview of the metaprivBIDS Graphical User Interface, including installation instructions, basic usage, and tutorial to get you started.
+This documentation provides an overview of the metaprivBIDS Graphical User Interface, including installation instructions, basic usage, and a tutorial to get you started.
 
-metaprivBIDS provides tool for data risk assessment, including methods:
+metaprivBIDS provides tools for data risk assessment, including methods:
 
 - K-anonymity [1]_
    - Searching each record in the dataset to see if they are indistinguishable from at least k − 1 other records with respect to a set of quasi-identifiers.
 
 - ℓ-diversity [2]_
-   - Looking at the diversity of the sensitive attribute. A dataset satisfies l-diversity if each group of indistinguishable records has at least l diverse values for the sensitive attribute(s), preventing easy inference of sensitive information.
+   - Looking at the diversity of the sensitive attribute. A dataset satisfies ℓ-diversity if each group of indistinguishable records has at least ℓ diverse values for the sensitive attribute(s), preventing easy inference of sensitive information.
 
 - Sample Unique Detection Algorithm (SUDA) [3]_
    - The SUDA (Sample Unique Detection Algorithm) identifies records in a dataset that are unique based on a combination of quasi-identifiers. It works by flagging records with rare attribute combinations, indicating a higher risk of re-identification.
@@ -24,7 +24,7 @@ metaprivBIDS provides tool for data risk assessment, including methods:
 
 
 - K-Global 
-   - K-Global attempts to capture individual variables K-anonymity contribution in the context of all other quasi-identifiers. This is done by evaluating the difference in unique row, given the removal of a given variable. To then account for the fact that e.g. continuous variables often result in more unique entries we normalise by the unique value counts of the column. Subsequently penalising variables with few unique values but a high impact on unique rows. 
+   - K-Global attempts to capture an individual variable's k-anonymity contribution in the context of all other quasi-identifiers. This is done by evaluating the difference in unique rows when a given variable is removed. To account for the fact that, for example, continuous variables often result in more unique entries, we normalise by each column's unique value counts, subsequently penalising variables with few unique values but a high impact on unique rows.
 
 
 .. [1] Sweeney, L. (2002). k-Anonymity: A Model for Protecting Privacy. *International Journal of Uncertainty, Fuzziness and Knowledge-Based Systems*, 10(05), 557-570.


### PR DESCRIPTION
## Summary
- correct spelling in README and installation guide
- clean up example tutorial text and heatmap description
- clarify intro to documentation and K-Global explanation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6895a48bd80c832585b3f939f13ea264