### PR TITLE
refactor packaging and update rpy2 conversion

### DIFF
--- a/metaprivBIDS/metaprivBIDS.py
+++ b/metaprivBIDS/metaprivBIDS.py
@@ -26,10 +26,7 @@ import io
 from rpy2 import robjects
 from rpy2.robjects.packages import importr
 from rpy2.robjects import pandas2ri
-
-
-# Activate pandas <-> R DataFrame conversion
-pandas2ri.activate()
+from rpy2.robjects.conversion import localconverter
 
 # Import the sdcMicro package
 sdcMicro = importr('sdcMicro')
@@ -1020,10 +1017,8 @@ class metaprivBIDS(QMainWindow):
             for col in df.select_dtypes(include=['object']).columns:
                 df[col] = df[col].astype('category').cat.codes
 
-           
-            r_df = robjects.DataFrame({
-                name: robjects.FloatVector(df[name].astype(float)) for name in df.columns
-            })
+            with localconverter(robjects.default_converter + pandas2ri.converter):
+                r_df = robjects.conversion.py2rpy(df.astype(float))
 
             
             suda_result = sdcMicro.suda2(r_df, missing=missing_value, DisFraction=dis_fraction)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<81", "wheel"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -23,8 +23,7 @@ dependencies = [
     "networkx>=2.6.3",
     "numpy>=1.21.6",
     "piflib>=0.1.1",
-    "scipy>=1.7.3",
-    "setuptools>=42"
+    "scipy>=1.7.3"
 ]
 
 [project.scripts]
@@ -33,8 +32,8 @@ metaprivBIDS = 'metaprivBIDS.metaprivBIDS:main'
 [project.urls]
 repository = "https://github.com/cpernet/metaprivBIDS"
 
-[tool.setuptools]
-packages = ["metaprivBIDS", "metaprivBIDS.corelogic"]
+[tool.setuptools.packages.find]
+include = ["metaprivBIDS*"]
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
## Summary
- require modern setuptools and remove it from runtime deps
- simplify package discovery to automatically include subpackages
- replace deprecated pandas2ri.activate with context-managed conversion

## Testing
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=68 (from versions: none))*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6895c90f17b08325a6c2148e548c8cab