### PR TITLE
Add interactive installer for optional pygraphviz dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Graphviz requires system-level dependencies as well as rpy2 and can be installed
 ```console
 conda create --name venv -c conda-forge "python>=3.7" graphviz r-base r-sdcMicro rpy2
 # Optional: conda install pygraphviz
+# (the provided install.py script will also prompt about this dependency)
 ```
 
 on windows, pif execute some command in sh terminal so also do
@@ -78,11 +79,14 @@ cd into the MetaprivBIDS folder
 ```console
 cd MetaprivBIDS
 ```
-and then run 
+and then run
 
 ```console
-pip install -e . 
+python install.py
 ```
+The script will ask whether to install the optional `pygraphviz` package.
+This script installs the package and prompts whether to include the optional
+`pygraphviz` dependency.
 
 
 ### Option 2 
@@ -106,8 +110,9 @@ To execute the program, make sure all dependencies from pyproject.toml are avail
 This can be done by first ```cd``` into the MetaprivBIDS directory and then running
 
 ```console
-pip install -e . 
+python install.py
 ```
+The script will ask whether to install the optional `pygraphviz` package.
 
 # Usage
 

--- a/install.py
+++ b/install.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Interactive installer for metaprivBIDS.
+
+This script prompts the user whether the optional ``pygraphviz``
+dependency should be installed.  ``pygraphviz`` is used for
+advanced graph visualisation but can be troublesome to install
+on Windows systems.  If the user declines, installation proceeds
+without it.
+"""
+
+import platform
+import subprocess
+import sys
+
+
+def main() -> None:
+    system = platform.system()
+    prompt = (
+        "Install optional 'pygraphviz' dependency for advanced graph "
+        "visualization? [y/N]: "
+    )
+    if system == "Windows":
+        print("pygraphviz often requires additional build tools on Windows.")
+    choice = input(prompt).strip().lower()
+    extra = "[pygraphviz]" if choice in {"y", "yes"} else ""
+    if extra:
+        print("Including pygraphviz in installation.")
+    else:
+        print("Skipping pygraphviz installation.")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", f".{extra}"])
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ readme = "README.md"
 requires-python = ">=3.7.4"
 
 dependencies = [
-    "pygraphviz>=1.7; sys_platform != 'win32'",
     "graphviz>=0.14",
     "tqdm>=4.62.3",
     "seaborn>=0.11.0",
@@ -49,6 +48,11 @@ docs = [
 # Test dependencies
 test = [
     "pytest>=3.0.5",
+]
+
+# Optional graph visualization dependency
+pygraphviz = [
+    "pygraphviz>=1.7",
 ]
 
 [tool.codespell]


### PR DESCRIPTION
## Summary
- remove mandatory pygraphviz dependency and expose it as optional extra
- add `install.py` script prompting whether to install pygraphviz
- document usage of interactive installer in README

## Testing
- `python -m py_compile install.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*

------
https://chatgpt.com/codex/tasks/task_e_689605b8e67883259ff26e94c75e9cef