### PR TITLE
Ensure pkg_resources available via setuptools dependency

### DIFF
--- a/metaprivBIDS/metaprivBIDS.py
+++ b/metaprivBIDS/metaprivBIDS.py
@@ -17,7 +17,14 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import networkx as nx
 from itertools import combinations
-import piflib.pif_calculator as pif
+try:
+    import piflib.pif_calculator as pif
+except ModuleNotFoundError as exc:
+    if exc.name == "pkg_resources":
+        raise ModuleNotFoundError(
+            "Required dependency 'pkg_resources' not found. Install 'setuptools' to provide it."
+        ) from exc
+    raise
 import seaborn as sns
 import matplotlib.colors as mcolors
 import io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies = [
     "networkx>=2.6.3",
     "numpy>=1.21.6",
     "piflib>=0.1.1",
-    "scipy>=1.7.3"
+    "scipy>=1.7.3",
+    "setuptools>=61"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Depend on `setuptools` at runtime so `pkg_resources` is available for `piflib`
- Provide a clear error message when `pkg_resources` is missing during `piflib` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas numpy` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_68960b4f398c832584769bc2dc5e24fb